### PR TITLE
The One Line Fix

### DIFF
--- a/addons/sourcemod/scripting/szf/pickupweapons.sp
+++ b/addons/sourcemod/scripting/szf/pickupweapons.sp
@@ -129,6 +129,7 @@ public Action Event_WeaponsRoundStart(Event event, const char[] name, bool dontB
 			}
 		}
 		
+		SetEntProp(iEntity, Prop_Send, "m_CollisionGroup", 2);
 		AcceptEntityInput(iEntity, "DisableShadow");
 		AcceptEntityInput(iEntity, "EnableCollision");
 		


### PR DESCRIPTION
Makes it so players can walk through weapons while still able to attack/pick them up.